### PR TITLE
Decrease KP3S Pro BAUDRATE for stable usb printing

### DIFF
--- a/config/examples/Kingroon/KP3S_Pro/Configuration.h
+++ b/config/examples/Kingroon/KP3S_Pro/Configuration.h
@@ -115,7 +115,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 //#define BAUD_RATE_GCODE     // Enable G-code M575 to set the baud rate
 


### PR DESCRIPTION
### Description

Decrease KP3S Pro baudrate for stable usb printing

### Benefits

Decrease KP3S pro BAUDRATE to overcome constant checksum mismatch and freezes